### PR TITLE
Run tests on push to renovate/** branch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, renovate/** ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
## Changes:

- Run the GitHub Action workflow on pushes to `renovate/**` branches (`**` is wildcard for one or more characters)

## Context:

I think your Renovate bot automerge is not working because you're not running the tests when Renovate pushes to the `renovate/**` branch. At the very least not running the tests causes Renovate bot to have to open a PR to run the tests, instead of silently merging when tests pass (which is probably what you wanted in the first place).

The Renovate docs have some explanation on what I'm doing here: https://docs.renovatebot.com/automerge-configuration/#branch-vs-pr-automerging

The GitHub docs, explains the use of the wildcard in the `branches:` property: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags