### PR TITLE
Use GitHub Action status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="CI Status" src="https://travis-ci.com/msallent/gatsby-starter-skeleton.svg?branch=master" />
+  <img alt="Node.js CI Status" src="https://github.com/msallent/gatsby-starter-skeleton/actions/workflows/node.js.yml/badge.svg" />
   <br />
   <br />
   <a href="https://gatsbyjs.org">


### PR DESCRIPTION
## Changes:

- Replace Travis CI badge with shiny new GitHub Action status badge

## Context:

For future reference, here is where you can learn how to add those badges:

[GitHub docs, adding a workflow status badge](https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge)